### PR TITLE
Fix data attributes && add ability to have script in HTML

### DIFF
--- a/macros/src/declare.rs
+++ b/macros/src/declare.rs
@@ -357,7 +357,7 @@ impl Declare {
                     write!(f, "<{}", #name)?;
                     #print_attrs
                     for (key, value) in &self.data_attributes {
-                        write!(f, " data-{}=\"{}\"", str::replace(key, "_", "-"),
+                        write!(f, " data-{}=\"{}\"", key,
                                crate::escape_html_attribute(value.to_string()))?;
                     }
                     for (key, value) in &self.aria_attributes {

--- a/macros/src/declare.rs
+++ b/macros/src/declare.rs
@@ -357,7 +357,7 @@ impl Declare {
                     write!(f, "<{}", #name)?;
                     #print_attrs
                     for (key, value) in &self.data_attributes {
-                        write!(f, " data-{}=\"{}\"", key,
+                        write!(f, " data-{}=\"{}\"", str::replace(key, "_", "-"),
                                crate::escape_html_attribute(value.to_string()))?;
                     }
                     for (key, value) in &self.aria_attributes {

--- a/macros/src/html.rs
+++ b/macros/src/html.rs
@@ -76,7 +76,10 @@ fn extract_data_attrs(attrs: &mut StringyMap<Ident, TokenTree>) -> StringyMap<St
         let key_name = key.to_string();
         if let Some(key_name) = key_name.strip_prefix("data_") {
             let value = attrs.remove(&key).unwrap();
-            data.insert(key_name.to_string(), value);
+            // makes sure if a data attribute has more than one hyphen
+            // they all get transformed
+            let key = str::replace(key_name, "_", "-");
+            data.insert(key.to_string(), value);
         }
     }
     data

--- a/typed-html/src/elements.rs
+++ b/typed-html/src/elements.rs
@@ -31,6 +31,7 @@ macro_rules! marker_trait {
     };
 }
 
+marker_trait!(HTMLContent);
 marker_trait!(MetadataContent);
 marker_trait!(FlowContent);
 marker_trait!(SectioningContent);
@@ -53,7 +54,7 @@ marker_trait!(TableColumnContent);
 declare_elements! {
     html {
         xmlns: Uri,
-    } with [head, body];
+    } with [head, body] HTMLContent;
     head with [title] MetadataContent;
     body with FlowContent;
 
@@ -311,7 +312,7 @@ declare_elements! {
         src: Uri,
         text: String,
         type: String, // TODO could be an enum
-    } in [MetadataContent, FlowContent, PhrasingContent, TableColumnContent] with TextNode;
+    } in [MetadataContent, FlowContent, PhrasingContent, TableColumnContent, HTMLContent] with TextNode;
     section in [FlowContent, SectioningContent] with FlowContent;
     select {
         autocomplete: String,


### PR DESCRIPTION
This PR does two things

- Fixes issue where if a data attribute has more than one `-` it would only make  the first one into an hyphen 
- Adds ability to add script tags in HTML so I can add the tracking code at the very bottom